### PR TITLE
Output files should always be available

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -8,7 +8,8 @@ const config = {
     entry: './src/index.js',
     output: {
         filename: 'bundle.js',
-        path: commonPaths.outputPath
+        path: commonPaths.outputPath,
+        publicPath: '/'
     },
     module: {
         rules: [


### PR DESCRIPTION
When using deeper URLs with router, the output files should be available in those pages components as well.

Example:
> http://my.site.tld/user/123456789